### PR TITLE
Use newer version of nokogiri

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'posix-spawn', "~> 0.3.0"
 gem 'sinatra', "~> 1.0"
 gem 'mustache', "< 1.0.0"
 gem 'sanitize', "~> 2.0.0"
-gem 'nokogiri', "~> 1.4"
+gem 'nokogiri'
 gem "twitter-bootstrap-rails"
 
 group :assets do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,7 @@ GEM
     mime-types (1.19)
     multi_json (1.3.6)
     mustache (0.99.4)
-    nokogiri (1.5.2)
+    nokogiri (1.5.11)
     orm_adapter (0.0.7)
     polyglot (0.3.3)
     posix-spawn (0.3.6)
@@ -235,7 +235,7 @@ DEPENDENCIES
   jquery-rails
   launchy
   mustache (< 1.0.0)
-  nokogiri (~> 1.4)
+  nokogiri
   posix-spawn (~> 0.3.0)
   pygments.rb (~> 0.2.0)
   rails (= 3.2.8)


### PR DESCRIPTION
This prevents build errors from occurring when installing on Ubuntu.
