### PR TITLE
Add hook to delete test wikis after each test

### DIFF
--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,0 +1,9 @@
+After do |scenario|
+  visit root_path
+  ["apple", "pear"].each do |wiki|
+    id = "delete_wiki-#{wiki}"
+    unless first(:css, "##{id}").nil?
+      click_on "#{id}"
+    end
+  end
+end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,9 +1,11 @@
 After do |scenario|
-  visit root_path
-  ["apple", "pear"].each do |wiki|
-    id = "delete_wiki-#{wiki}"
-    unless first(:css, "##{id}").nil?
-      click_on "#{id}"
+  if scenario.passed?
+    visit root_path
+    ["apple", "pear"].each do |wiki|
+      id = "delete_wiki-#{wiki}"
+      unless first(:css, "##{id}").nil?
+        click_on "#{id}"
+      end
     end
   end
 end


### PR DESCRIPTION
Previously, the test wiki folders remained between tests, and this could cause test failures, especially when running the tests multiple times in a row.
