### PR TITLE
Disable new registrations

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -31,6 +31,8 @@ weird characters) and then you will be able to click on your wiki and browse/edi
 
 You can then click on add wiki, give it a name (No spaces or weird characters) and then you will be able to click on your wiki and browse/edit it.
 
+To enable new registrations, set the +allow_registrations+ setting to +1+. With this setting disabled, new users will not be permitted to create an account.
+
 == Contributors / Thanks
 
 Scott Weldon (501st-alpha1)

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -8,15 +8,18 @@ class SettingsController < ApplicationController
   end
 
   def update
-    @setting = Setting.find_or_initialize_by(key: 'application_name')
+    ['application_name', 'allow_registrations'].each do |item|
+      setting = Setting.find_or_initialize_by(key: item)
+      input = resource_params[item]
 
-    if @setting.update_attributes(value: resource_params[:application_name][:value])
-      redirect_to settings_path, flash: {success: "Settings saved"}
-    else
-      flash.now[:error] = "Could not save settings"
-      @settings = load_settings
-      render :edit
+      if !setting.update_attributes(value: input[:value])
+        flash.now[:error] = "Could not save setting " + item
+        @settings = load_settings
+        render :edit
+      end
     end
+
+    redirect_to settings_path, flash: {success: "Settings saved"}
   end
 
   def resource_params

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -20,10 +20,12 @@ class SettingsController < ApplicationController
   end
 
   def resource_params
-    params.require(:settings).permit(application_name: [:value])
+    params.require(:settings).permit(application_name: [:value],
+                                     allow_registrations: [:value])
   end
 
   def load_settings
-    [Setting.find_or_initialize_by(key: 'application_name')]
+    [Setting.find_or_initialize_by(key: 'application_name'),
+     Setting.find_or_initialize_by(key: 'allow_registrations')]
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -3,14 +3,22 @@ class Users::RegistrationsController < Devise::RegistrationsController
 # before_filter :configure_account_update_params, only: [:update]
 
   # GET /resource/sign_up
-  # def new
-  #   super
-  # end
+  def new
+    if Setting.find_or_initialize_by(key: 'allow_registrations').value != "1"
+      redirect_to "/users/sign_in", flash: {error: "New sign ups are not allowed."}
+    else
+      super
+    end
+  end
 
   # POST /resource
-  # def create
-  #   super
-  # end
+  def create
+    if Setting.find_or_initialize_by(key: 'allow_registrations').value != "1"
+      redirect_to "/users/sign_in", flash: {error: "New sign ups are not allowed."}
+    else
+      super
+    end
+  end
 
   # GET /resource/edit
   # def edit

--- a/features/signups_disabled.feature
+++ b/features/signups_disabled.feature
@@ -1,0 +1,11 @@
+Feature: Users can't sign up when registrations are disabled
+    Background:
+        Given registrations are "disabled"
+
+    Scenario: Load disabled sign up page
+        When I am on the sign up page
+        Then I should see "New sign ups are not allowed."
+
+    Scenario: POST to disabled sign up page
+        When I submit a new signup
+        Then I should see "New sign ups are not allowed."

--- a/features/signups_enabled.feature
+++ b/features/signups_enabled.feature
@@ -1,0 +1,12 @@
+Feature: Users can sign up when registrations are enabled
+    Background:
+        Given registrations are "enabled"
+
+    Scenario: Successful sign up
+        When I am on the sign up page
+        Then I should see "Sign up"
+        And I register as "test@example.com"
+        Then I should see "Welcome! You have signed up successfully."
+
+    # Clean up
+        Then I should delete user "test@example.com"

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -11,3 +11,31 @@ Given /^I am logged in as a user$/ do
   fill_in "user_password", :with => "12345678"
   click_on "Log in"
 end
+
+Given(/^registrations are "([^"]*)"$/) do |state|
+  value = (state == "enabled") ? "1" : "0"
+  setting = Setting.find_or_initialize_by(:key => "allow_registrations")
+  setting.update_attributes(:value => value)
+end
+
+When(/^I am on the sign up page$/) do
+  visit "/users/sign_up"
+end
+
+When(/^I submit a new signup$/) do
+  page.driver.post("/users", { :params => { :user_email => "test@example.com" } })
+  expect(page.driver.status_code).to eq(302)
+  visit page.driver.response.location
+end
+
+When(/^I register as "([^"]*)"$/) do |email|
+  fill_in "user_email", :with => email
+  fill_in "user_password", :with => "12345678"
+  fill_in "user_password_confirmation", :with => "12345678"
+  click_on "Sign up"
+end
+
+Then(/^I should delete user "([^"]*)"$/) do |email|
+  user = User.find_by(:email => email)
+  user.destroy!
+end


### PR DESCRIPTION
Implemented feature and added Cucumber tests.

Right now the string value `"1"` is considered "enabled", and anything else is "disabled". All we need is true/false, but `Setting`s are saved as strings.

Fixes #24.